### PR TITLE
Hotfix to disable the admin path, the application has its own management procedure

### DIFF
--- a/networkapi/urls.py
+++ b/networkapi/urls.py
@@ -10,9 +10,6 @@ from django.http import HttpResponse
 from networkapi.check.CheckAction import CheckAction
 # from django.conf.urls.defaults import *
 
-# Uncomment the next two lines to enable the admin:
-# from django.contrib import admin
-admin.autodiscover()
 
 api_prefix = r'^api/'
 
@@ -141,8 +138,6 @@ urlpatterns = patterns(
     # eventlog
     url(r'^eventlog/', include('networkapi.eventlog.urls')),
 
-    # django admin
-    url(r'^admin/', include(admin.site.urls)),
 )
 
 if settings.DEBUG:


### PR DESCRIPTION
This solution fixes the problem to have the admin path set up, a security breach.