### PR TITLE
Add the entire path in Cumulus Plugin

### DIFF
--- a/networkapi/plugins/Cumulus/plugin.py
+++ b/networkapi/plugins/Cumulus/plugin.py
@@ -24,6 +24,7 @@ from time import sleep
 from rest_framework import status
 from CumulusExceptions import *
 from networkapi.equipamento.models import EquipamentoAcesso
+from networkapi.settings import TFTPBOOT_FILES_PATH
 from ..base import BasePlugin
 from .. import exceptions
 
@@ -80,9 +81,13 @@ class Cumulus(BasePlugin):
 
     def _get_conf_from_file(self, filename):
         """Get the configurations needed to be applied
-            and insert into a list"""
+            and insert into a list
+
+            TFTPBOOT_FILES_PATH is required so we can read
+            the generated config file
+            """
         try:
-            with open(filename, 'r+') as lines:
+            with open(TFTPBOOT_FILES_PATH + filename, 'r+') as lines:
                 for line in lines:
                     self._command_list.append(line)
         except IOError as e:

--- a/networkapi/plugins/Cumulus/plugin.py
+++ b/networkapi/plugins/Cumulus/plugin.py
@@ -37,6 +37,7 @@ class Cumulus(BasePlugin):
     HTTP = httplib2.Http('.cache', disable_ssl_certificate_validation=True)
     HEADERS = {'Content-Type': 'application/json; charset=UTF-8'}
     httplib2.RETRIES = 3
+
     # Cumulus commands to control the staging area
     COMMIT = {'cmd': 'commit'}
     ABORT_CHANGES = {'cmd': 'abort'}


### PR DESCRIPTION
For the Cumulus plugin read the file generated, it needs to get the entire TFTP path.