### PR TITLE
Adds caching possibility to environment v3 search

### DIFF
--- a/networkapi/ambiente/models.py
+++ b/networkapi/ambiente/models.py
@@ -46,8 +46,8 @@ from networkapi.util import is_valid_text
 from networkapi.util.geral import create_lock_with_blocking
 from networkapi.util.geral import destroy_lock
 from networkapi.util.geral import get_app
-from networkapi.util.cache import delete_cached_searches_list
-from networkapi.util.cache import ENVIRONMENT_CACHE_ENTRY
+from networkapi.util.appcache import delete_cached_searches_list
+from networkapi.util.appcache import ENVIRONMENT_CACHE_ENTRY
 
 log = logging.getLogger(__name__)
 

--- a/networkapi/api_environment/facade.py
+++ b/networkapi/api_environment/facade.py
@@ -25,8 +25,17 @@ from networkapi.infrastructure.datatable import build_query_to_datatable_v3
 from networkapi.plugins.factory import PluginFactory
 from networkapi.api_equipment import exceptions as exceptions_eqpt
 from networkapi.api_equipment import facade as facade_eqpt
+from networkapi.system.facade import get_value
+from networkapi.util.appcache import DEFAULT_CACHE_TIMEOUT
 
 log = logging.getLogger(__name__)
+
+
+def get_environment_cache_time():
+    try:
+        return int(get_value('ENVIRONMENT_CACHE_TIMEOUT'))
+    except Exception as e:
+        return DEFAULT_CACHE_TIMEOUT
 
 
 def get_l3_environment_by_search(search=dict()):

--- a/networkapi/api_environment/facade.py
+++ b/networkapi/api_environment/facade.py
@@ -26,7 +26,6 @@ from networkapi.plugins.factory import PluginFactory
 from networkapi.api_equipment import exceptions as exceptions_eqpt
 from networkapi.api_equipment import facade as facade_eqpt
 
-
 log = logging.getLogger(__name__)
 
 

--- a/networkapi/api_environment/views.py
+++ b/networkapi/api_environment/views.py
@@ -196,9 +196,11 @@ class EnvironmentDBView(CustomAPIView):
     def get(self, request, *args, **kwargs):
         """Returns a list of environment by ids ou dict."""
 
-        if not kwargs.get('obj_ids'):
+        # String with all important fields to define response
+        request_identifier_to_cache = str(self.search)+str(self.fields)+str(self.include)+str(self.exclude)+str(self.kind)
 
-            data = get_cached_search(ENVIRONMENT_CACHE_ENTRY, self.search)
+        if not kwargs.get('obj_ids'):
+            data = get_cached_search(ENVIRONMENT_CACHE_ENTRY, request_identifier_to_cache)
             if data:
                 return Response(data, status=status.HTTP_200_OK)
 
@@ -230,7 +232,7 @@ class EnvironmentDBView(CustomAPIView):
             only_main_property=only_main_property
         )
 
-        set_cache_search_with_list(ENVIRONMENT_CACHE_ENTRY, self.search, data)
+        set_cache_search_with_list(ENVIRONMENT_CACHE_ENTRY, request_identifier_to_cache, data)
         return Response(data, status=status.HTTP_200_OK)
 
     @logs_method_apiview

--- a/networkapi/api_environment/views.py
+++ b/networkapi/api_environment/views.py
@@ -19,6 +19,12 @@ from networkapi.util.geral import render_to_json
 from networkapi.util.json_validate import json_validate
 from networkapi.util.json_validate import raise_json_validate
 
+from networkapi.util.cache import get_cached_search
+from networkapi.util.cache import delete_cached_searches_list
+from networkapi.util.cache import set_cache_search_with_list
+from networkapi.util.cache import ENVIRONMENT_CACHE_ENTRY
+
+
 log = logging.getLogger(__name__)
 
 
@@ -191,6 +197,11 @@ class EnvironmentDBView(CustomAPIView):
         """Returns a list of environment by ids ou dict."""
 
         if not kwargs.get('obj_ids'):
+
+            data = get_cached_search(ENVIRONMENT_CACHE_ENTRY, self.search)
+            if data:
+                return Response(data, status=status.HTTP_200_OK)
+
             obj_model = facade.get_environment_by_search(self.search)
             environments = obj_model['query_set']
             only_main_property = False
@@ -219,6 +230,7 @@ class EnvironmentDBView(CustomAPIView):
             only_main_property=only_main_property
         )
 
+        set_cache_search_with_list(ENVIRONMENT_CACHE_ENTRY, self.search, data)
         return Response(data, status=status.HTTP_200_OK)
 
     @logs_method_apiview

--- a/networkapi/api_environment/views.py
+++ b/networkapi/api_environment/views.py
@@ -19,10 +19,10 @@ from networkapi.util.geral import render_to_json
 from networkapi.util.json_validate import json_validate
 from networkapi.util.json_validate import raise_json_validate
 
-from networkapi.util.cache import get_cached_search
-from networkapi.util.cache import delete_cached_searches_list
-from networkapi.util.cache import set_cache_search_with_list
-from networkapi.util.cache import ENVIRONMENT_CACHE_ENTRY
+from networkapi.util.appcache import get_cached_search
+from networkapi.util.appcache import delete_cached_searches_list
+from networkapi.util.appcache import set_cache_search_with_list
+from networkapi.util.appcache import ENVIRONMENT_CACHE_ENTRY
 
 
 log = logging.getLogger(__name__)

--- a/networkapi/api_environment/views.py
+++ b/networkapi/api_environment/views.py
@@ -197,10 +197,12 @@ class EnvironmentDBView(CustomAPIView):
         """Returns a list of environment by ids ou dict."""
 
         # String with all important fields to define response
-        request_identifier_to_cache = str(self.search)+str(self.fields)+str(self.include)+str(self.exclude)+str(self.kind)
+        request_identifier_to_cache = str(
+            self.search)+str(self.fields)+str(self.include)+str(self.exclude)+str(self.kind)
 
         if not kwargs.get('obj_ids'):
-            data = get_cached_search(ENVIRONMENT_CACHE_ENTRY, request_identifier_to_cache)
+            data = get_cached_search(
+                ENVIRONMENT_CACHE_ENTRY, request_identifier_to_cache)
             if data:
                 return Response(data, status=status.HTTP_200_OK)
 
@@ -232,7 +234,8 @@ class EnvironmentDBView(CustomAPIView):
             only_main_property=only_main_property
         )
 
-        set_cache_search_with_list(ENVIRONMENT_CACHE_ENTRY, request_identifier_to_cache, data)
+        set_cache_search_with_list(
+            ENVIRONMENT_CACHE_ENTRY, request_identifier_to_cache, data, facade.get_environment_cache_time())
         return Response(data, status=status.HTTP_200_OK)
 
     @logs_method_apiview

--- a/networkapi/util/appcache.py
+++ b/networkapi/util/appcache.py
@@ -4,65 +4,79 @@ import logging
 from django.core.cache import cache as djangocache
 
 from networkapi.distributedlock import distributedlock
+from networkapi.system.facade import get_value
+
 
 log = logging.getLogger(__name__)
 
 
 DEFAULT_CACHE_TIMEOUT = 86400
-
 ENVIRONMENT_CACHE_ENTRY = "CACHE_ENV_LIST"
+
+
+def cache_enabled():
+    try:
+        if int(get_value('use_cache')):
+            return 1
+        return 0
+    except Exception as e:
+        return 0
 
 
 def get_cached_search(prefix, search):
 
-    try:
-        search_md5 = hashlib.md5(str(search)).hexdigest()
-        key = prefix+search_md5
-        data = djangocache.get(key)
-        if data:
-            log.debug("Got cached data for key %s" % key)
-        return data
-    except Exception as e:
-        log.error(e)
-        return None
+    if cache_enabled():
+        try:
+            search_md5 = hashlib.md5(str(search)).hexdigest()
+            key = prefix+search_md5
+            data = djangocache.get(key)
+            if data:
+                log.debug("Got cached data for key %s" % key)
+            return data
+        except Exception as e:
+            log.error(e)
+            return None
 
 
 def set_cache_search_with_list(prefix, search, data, timeout=DEFAULT_CACHE_TIMEOUT):
 
-    with distributedlock(prefix):
-        try:
-            search_md5 = hashlib.md5(str(search)).hexdigest()
-            key = prefix+search_md5
-            djangocache.set(key, data, timeout)
+    if cache_enabled():
+        with distributedlock(prefix):
+            try:
+                search_md5 = hashlib.md5(str(search)).hexdigest()
+                key = prefix+search_md5
+                djangocache.set(key, data, timeout)
 
-            cached_search_md5_list = djangocache.get(prefix)
-            if not cached_search_md5_list:
-                cached_search_md5_list = []
+                cached_search_md5_list = djangocache.get(prefix)
+                if not cached_search_md5_list:
+                    cached_search_md5_list = []
 
-            if search_md5 not in cached_search_md5_list:
-                cached_search_md5_list.append(search_md5)
+                if search_md5 not in cached_search_md5_list:
+                    cached_search_md5_list.append(search_md5)
 
-            log.debug("Caching key %s in list %s ..." % (key, prefix))
-            key = prefix
-            djangocache.set(key, cached_search_md5_list, timeout)
-        except Exception as e:
-            log.error(e)
+                log.debug("Caching key %s in list %s with timeout %s..." %
+                          (key, prefix, timeout))
+                key = prefix
+                djangocache.set(key, cached_search_md5_list, timeout)
+            except Exception as e:
+                log.error(e)
 
 
 def delete_cached_searches_list(prefix):
 
-    with distributedlock(prefix):
-        try:
-            cached_search_md5_list = djangocache.get(prefix)
-            if cached_search_md5_list:
-                for cached_search_md5 in cached_search_md5_list:
-                    key = str(prefix)+str(cached_search_md5)
-                    log.debug("Deleting cache entry %s ... " % key)
-                    djangocache.delete(key)
-                log.debug("Deleting cache list entry %s ..." % prefix)
-                djangocache.delete(prefix)
-        except Exception as e:
-            log.error(e)
-            raise e
+    if cache_enabled():
+        with distributedlock(prefix):
+            try:
+                cached_search_md5_list = djangocache.get(prefix)
+                if cached_search_md5_list:
+                    for cached_search_md5 in cached_search_md5_list:
+                        key = str(prefix)+str(cached_search_md5)
+                        log.debug("Deleting cache entry %s ... " % key)
+                        djangocache.delete(key)
+                    log.debug("Deleting cache list entry %s ..." % prefix)
+                    djangocache.delete(prefix)
+            except Exception as e:
+                log.error(e)
+                raise e
 
-        return True
+            return True

--- a/networkapi/util/appcache.py
+++ b/networkapi/util/appcache.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 
-from django.core.cache import cache as memcache
+from django.core.cache import cache as djangocache
 
 from networkapi.distributedlock import distributedlock
 
@@ -18,7 +18,7 @@ def get_cached_search(prefix, search):
     try:
         search_md5 = hashlib.md5(str(search)).hexdigest()
         key = prefix+search_md5
-        data = memcache.get(key)
+        data = djangocache.get(key)
         if data:
             log.debug("Got cached data for key %s" % key)
         return data
@@ -33,9 +33,9 @@ def set_cache_search_with_list(prefix, search, data, timeout=DEFAULT_CACHE_TIMEO
         try:
             search_md5 = hashlib.md5(str(search)).hexdigest()
             key = prefix+search_md5
-            memcache.set(key, data, timeout)
+            djangocache.set(key, data, timeout)
 
-            cached_search_md5_list = memcache.get(prefix)
+            cached_search_md5_list = djangocache.get(prefix)
             if not cached_search_md5_list:
                 cached_search_md5_list = []
 
@@ -44,7 +44,7 @@ def set_cache_search_with_list(prefix, search, data, timeout=DEFAULT_CACHE_TIMEO
 
             log.debug("Caching key %s in list %s ..." % (key, prefix))
             key = prefix
-            memcache.set(key, cached_search_md5_list, timeout)
+            djangocache.set(key, cached_search_md5_list, timeout)
         except Exception as e:
             log.error(e)
 
@@ -53,14 +53,14 @@ def delete_cached_searches_list(prefix):
 
     with distributedlock(prefix):
         try:
-            cached_search_md5_list = memcache.get(prefix)
+            cached_search_md5_list = djangocache.get(prefix)
             if cached_search_md5_list:
                 for cached_search_md5 in cached_search_md5_list:
                     key = str(prefix)+str(cached_search_md5)
                     log.debug("Deleting cache entry %s ... " % key)
-                    memcache.delete(key)
+                    djangocache.delete(key)
                 log.debug("Deleting cache list entry %s ..." % prefix)
-                memcache.delete(prefix)
+                djangocache.delete(prefix)
         except Exception as e:
             log.error(e)
             raise e

--- a/networkapi/util/cache.py
+++ b/networkapi/util/cache.py
@@ -1,0 +1,68 @@
+import hashlib
+import logging
+
+from django.core.cache import cache as memcache
+
+from networkapi.distributedlock import distributedlock
+
+log = logging.getLogger(__name__)
+
+
+DEFAULT_CACHE_TIMEOUT = 86400
+
+ENVIRONMENT_CACHE_ENTRY = "CACHE_ENV_LIST"
+
+
+def get_cached_search(prefix, search):
+
+    try:
+        search_md5 = hashlib.md5(str(search)).hexdigest()
+        key = prefix+search_md5
+        data = memcache.get(key)
+        if data:
+            log.debug("Got cached data for key %s" % key)
+        return data
+    except Exception as e:
+        log.error(e)
+        return None
+
+
+def set_cache_search_with_list(prefix, search, data, timeout=DEFAULT_CACHE_TIMEOUT):
+
+    with distributedlock(prefix):
+        try:
+            search_md5 = hashlib.md5(str(search)).hexdigest()
+            key = prefix+search_md5
+            memcache.set(key, data, timeout)
+
+            cached_search_md5_list = memcache.get(prefix)
+            if not cached_search_md5_list:
+                cached_search_md5_list = []
+
+            if search_md5 not in cached_search_md5_list:
+                cached_search_md5_list.append(search_md5)
+
+            log.debug("Caching key %s in list %s ..." % (key, prefix))
+            key = prefix
+            memcache.set(key, cached_search_md5_list, timeout)
+        except Exception as e:
+            log.error(e)
+
+
+def delete_cached_searches_list(prefix):
+
+    with distributedlock(prefix):
+        try:
+            cached_search_md5_list = memcache.get(prefix)
+            if cached_search_md5_list:
+                for cached_search_md5 in cached_search_md5_list:
+                    key = str(prefix)+str(cached_search_md5)
+                    log.debug("Deleting cache entry %s ... " % key)
+                    memcache.delete(key)
+                log.debug("Deleting cache list entry %s ..." % prefix)
+                memcache.delete(prefix)
+        except Exception as e:
+            log.error(e)
+            raise e
+
+        return True

--- a/networkapi/util/geral.py
+++ b/networkapi/util/geral.py
@@ -14,7 +14,6 @@ from networkapi.distributedlock import distributedlock
 from networkapi.distributedlock import LockNotAcquiredError
 from networkapi.extra_logging import local
 
-
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Uses django cache to accelerate environment v3 search results. Different searches are kept in cache identified by md5. A list of the cached searches is also kept in cache in order to invalidate entries when needed.
Caching functions uses system variables to control caching:
use_cache = 0 or 1 - enable or disable caching
ENVIRONMENT_CACHE_TIMEOUT = seconds to keep cache entry for environment search