### PR TITLE
remove localhost (127.0.0.1) from netapi_app container for remote access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,8 +56,8 @@ services:
         image: globocom/networkapi:latest
         restart: always
         ports:
-            - "127.0.0.1:8000:8000"
-            - "127.0.0.1:8001:8001"
+            - "8000:8000"
+            - "8001:8001"
         env_file:
             - scripts/docker/netapi.env
         volumes:


### PR DESCRIPTION
When running inside windows wsl (that runs on a VM) the service needs to be exposed from the WSL VM to the host machine. 127.0.0.1 restricts the access only inside VM.