### PR TITLE
fix: replace bare except with except Exception in EnvironmentGetByEqu…

### DIFF
--- a/networkapi/ambiente/resource/EnvironmentGetByEquipResource.py
+++ b/networkapi/ambiente/resource/EnvironmentGetByEquipResource.py
@@ -76,7 +76,7 @@ class EnvironmentGetByEquipResource(RestResource):
                     if env.min_num_vlan_1 != env.min_num_vlan_2:
                         env_map['range'] = env_map[
                             'range'] + '; ' + str(env.min_num_vlan_2) + ' - ' + str(env.max_num_vlan_2)
-                except:
+                except Exception:
                     env_map['range'] = 'Nao definido'
         
                 if env.filter is not None:


### PR DESCRIPTION
…ipResource

Replace bare `except:` clause with `except Exception:` on line 79.

A bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which can mask critical errors and make debugging harder. Since this block simply sets a fallback value without re-raising, `except Exception:` is the correct fix (PEP 8 E722).

No behavioral change for normal operation — only system-level exceptions are no longer silently swallowed.