### PR TITLE
fix: replace bare except with except Exception in v1.py

### DIFF
--- a/networkapi/api_network/facade/v1.py
+++ b/networkapi/api_network/facade/v1.py
@@ -594,7 +594,7 @@ def _load_template_file(equipment, template_type):
     try:
         equipment_template = (EquipamentoRoteiro.search(
             None, equipment.id, template_type)).uniqueResult()
-    except:
+    except Exception:
         log.error('Template type %s not found.' % template_type)
         raise exceptions.NetworkTemplateException()
 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in _load_template_file (line 597).

Bare `except:` catches all exceptions including SystemExit, KeyboardInterrupt, and GeneratorExit, which can mask critical errors and make debugging harder (PEP 8 E722).

Since this block handles a fallback case without re-raising the original exception, `except Exception:` is the correct narrower alternative. No behavioral change for normal operation.