### PR TITLE
PCEC-163: persist port_channel status_deploy on deploy/undeploy

### DIFF
--- a/networkapi/api_interface/facade.py
+++ b/networkapi/api_interface/facade.py
@@ -40,6 +40,7 @@ from networkapi.infrastructure.datatable import build_query_to_datatable_v3
 from networkapi.interface.models import EnvironmentInterface
 from networkapi.interface.models import Interface
 from networkapi.interface.models import PortChannel
+from networkapi.interface.models import StatusDeploy
 from networkapi.interface.models import TipoInterface
 from networkapi.interface import models
 from networkapi.system import exceptions as var_exceptions
@@ -506,13 +507,19 @@ def generate_and_deploy_channel_config_sync(user, id_channel):
 
     # TODO Deploy config file
     # make separate threads
-    for equipment_id in files_to_deploy.keys():
-        lockvar = LOCK_INTERFACE_DEPLOY_CONFIG % (equipment_id)
-        equipamento = Equipamento.get_by_pk(equipment_id)
-        status_deploy = deploy_config_in_equipment_synchronous(
-            files_to_deploy[equipment_id], equipamento, lockvar)
-    
+    try:
+        for equipment_id in files_to_deploy.keys():
+            lockvar = LOCK_INTERFACE_DEPLOY_CONFIG % (equipment_id)
+            equipamento = Equipamento.get_by_pk(equipment_id)
+            status_deploy = deploy_config_in_equipment_synchronous(
+                files_to_deploy[equipment_id], equipamento, lockvar)
+    except Exception:
+        channel.status_deploy = StatusDeploy.error[0]
+        channel.save(user)
+        raise
+
     channel.last_deploy = datetime.now()
+    channel.status_deploy = StatusDeploy.deployed[0]
     channel.save(user)
 
     return status_deploy

--- a/networkapi/api_interface/serializers.py
+++ b/networkapi/api_interface/serializers.py
@@ -59,6 +59,9 @@ class PortChannelSerializer(DynamicFieldsModelSerializer):
             'id',
             'name',
             'lacp',
+            'status_deploy',
+            'last_deploy',
+            'last_undeploy',
         )
 
         default_fields = fields
@@ -66,7 +69,10 @@ class PortChannelSerializer(DynamicFieldsModelSerializer):
         basic_fields = (
             'id',
             'name',
-            'lacp'
+            'lacp',
+            'status_deploy',
+            'last_deploy',
+            'last_undeploy',
         )
 
         details_fields = fields

--- a/networkapi/interface/resource/InterfaceChannelResource.py
+++ b/networkapi/interface/resource/InterfaceChannelResource.py
@@ -32,6 +32,7 @@ from networkapi.interface.models import Interface
 from networkapi.interface.models import InterfaceError
 from networkapi.interface.models import InterfaceNotFoundError
 from networkapi.interface.models import PortChannel
+from networkapi.interface.models import StatusDeploy
 from networkapi.interface.models import TipoInterface
 from networkapi.rest import RestResource
 from networkapi.rest import UserNotAuthorizedError
@@ -336,35 +337,42 @@ class InterfaceChannelResource(RestResource):
             tipo = tipo.get_by_name('access')
 
             # For each equipment (leaf), undeploy port channel config
-            for e in equip_dict:
-                if not keep_db:
-                    for i in equip_dict.get(e):
-                        try:
-                            front = i.ligacao_front.id
-                        except:
-                            front = None
-                            pass
-                        try:
-                            back = i.ligacao_back.id
-                        except:
-                            back = None
-                            pass
-                        i.update(user,
-                                 i.id,
-                                 interface=i.interface,
-                                 protegida=i.protegida,
-                                 descricao=i.descricao,
-                                 ligacao_front_id=front,
-                                 ligacao_back_id=back,
-                                 tipo=tipo,
-                                 vlan_nativa='1')
+            try:
+                for e in equip_dict:
+                    if not keep_db:
+                        for i in equip_dict.get(e):
+                            try:
+                                front = i.ligacao_front.id
+                            except:
+                                front = None
+                                pass
+                            try:
+                                back = i.ligacao_back.id
+                            except:
+                                back = None
+                                pass
+                            i.update(user,
+                                     i.id,
+                                     interface=i.interface,
+                                     protegida=i.protegida,
+                                     descricao=i.descricao,
+                                     ligacao_front_id=front,
+                                     ligacao_back_id=back,
+                                     tipo=tipo,
+                                     vlan_nativa='1')
 
-                api_interface_facade.delete_channel(user, e, equip_dict.get(e), channel)
+                    api_interface_facade.delete_channel(user, e, equip_dict.get(e), channel)
+            except Exception:
+                if keep_db:
+                    channel.status_deploy = StatusDeploy.error[0]
+                    channel.save(user)
+                raise
 
             if not keep_db:
                 channel.delete(user)
             else:
                 channel.last_undeploy = datetime.now()
+                channel.status_deploy = StatusDeploy.pending[0]
                 channel.save(user)
 
             return self.response(dumps_networkapi({}))


### PR DESCRIPTION
Persiste e atualiza o status_deploy do PortChannel (pending/deployed/error) nas operacoes de deploy e undeploy, seguindo o mesmo padrao usado pela PCEC-165 para last_deploy/last_undeploy. Tambem expoe status_deploy/last_deploy/last_undeploy no PortChannelSerializer usado pelo endpoint de listagem do networkapi-portchannel.